### PR TITLE
Bug at Springer.

### DIFF
--- a/src/arcas/Springer/main.py
+++ b/src/arcas/Springer/main.py
@@ -59,6 +59,7 @@ class Springer(Api):
         for key, value in raw_article:
             if key not in d:
                 if value is not None:
+                    value = value.replace(',', ' ')
                     d[key] = value
             else:
                 if value is not None:


### PR DESCRIPTION
Closes #16.

The bug has been the following:

For the first author, from the list of authors, his/her last-name and firs-name were separating.  