### PR TITLE
fix parameters.

### DIFF
--- a/bin/arcas_scrape
+++ b/bin/arcas_scrape
@@ -38,7 +38,9 @@ if __name__ == '__main__':
     validate = ast.literal_eval(arguments['-v'])
 
     # generate the parameters
-    parameters = api.parameters_fix(arguments)
+    parameters = api.parameters_fix(author=arguments['-a'], title=arguments['-t'],
+                                    abstract=arguments['-b'], year=arguments['-y'],
+                                    records=arguments['-r'], start=arguments['-s'])
     # generate url
     url = api.create_url_search(parameters)
     print(url)

--- a/src/arcas/IEEE/main.py
+++ b/src/arcas/IEEE/main.py
@@ -58,19 +58,20 @@ class Ieee(Api):
         return raw_articles
 
     @staticmethod
-    def parameters_fix(arguments):
+    def parameters_fix(author=None, title=None, abstract=None, year=None,
+                       records=None, start=None):
         parameters = []
-        if arguments['-a'] is not None:
-            parameters.append('au={}'.format(arguments['-a']))
-        if arguments['-t'] is not None:
-            parameters.append('ti={}'.format(arguments['-t']))
-        if arguments['-b'] is not None:
-            parameters.append('ab={}'.format(arguments['-b']))
-        if arguments['-y'] is not None:
-            parameters.append('py={}'.format(arguments['-y']))
-        if arguments['-r'] is not None:
-            parameters.append('hc={}'.format(arguments['-r']))
-        if arguments['-s'] is not None:
-            parameters.append('rs={}'.format(arguments['-s']))
+        if author is not None:
+            parameters.append('au={}'.format(author))
+        if title is not None:
+            parameters.append('ti={}'.format(title))
+        if abstract is not None:
+            parameters.append('ab={}'.format(abstract))
+        if year is not None:
+            parameters.append('py={}'.format(year))
+        if records is not None:
+            parameters.append('hc={}'.format(records))
+        if start is not None:
+            parameters.append('rs={}'.format(start))
 
         return parameters

--- a/src/arcas/PLOS/main.py
+++ b/src/arcas/PLOS/main.py
@@ -89,22 +89,23 @@ class Plos(Api):
         return [self.xml_to_dict(raw_article) for raw_article in raw_articles]
 
     @staticmethod
-    def parameters_fix(arguments):
+    def parameters_fix(author=None, title=None, abstract=None, year=None,
+                       records=None, start=None):
         parameters = []
-        if arguments['-a'] is not None:
-            parameters.append('author:{}'.format(arguments['-a']))
-        if arguments['-t'] is not None:
-            parameters.append('title:{}'.format(arguments['-t']))
-        if arguments['-b'] is not None:
-            parameters.append('abstract:{}'.format(arguments['-b']))
-        if arguments['-y'] is not None:
+        if author is not None:
+            parameters.append('author:{}'.format(author))
+        if title is not None:
+            parameters.append('title:{}'.format(title))
+        if abstract is not None:
+            parameters.append('abstract:{}'.format(abstract))
+        if year is not None:
             parameters.append('publication_date:[{0}-01-01T00:00:00Z TO '
                               '{0}-12-30T23:59:59Z]'
-                              .format(arguments['-y']))
-        if arguments['-r'] is not None:
-            parameters.append('rows={}'.format(arguments['-r']))
-        if arguments['-s'] is not None:
-            parameters.append('start={}'.format(arguments['-s']))
+                              .format(year))
+        if records is not None:
+            parameters.append('rows={}'.format(records))
+        if start is not None:
+            parameters.append('start={}'.format(start))
 
         return parameters
 

--- a/src/arcas/Springer/main.py
+++ b/src/arcas/Springer/main.py
@@ -86,18 +86,19 @@ class Springer(Api):
         return [self.xml_to_dict(raw_article) for raw_article in raw_articles]
 
     @staticmethod
-    def parameters_fix(arguments):
+    def parameters_fix(author=None, title=None, abstract=None, year=None,
+                       records=None, start=None):
         parameters = []
-        if arguments['-a'] is not None:
-            parameters.append('name:{}'.format(arguments['-a']))
-        if arguments['-t'] is not None:
-            parameters.append('title:{}'.format(arguments['-t']))
-        if arguments['-y'] is not None:
-            parameters.append('year:{}'.format(arguments['-y']))
-        if arguments['-r'] is not None:
-            parameters.append('p={}'.format(arguments['-r']))
-        if arguments['-s'] is not None:
-            parameters.append('s={}'.format(arguments['-s']))
+        if author is not None:
+            parameters.append('name:{}'.format(author))
+        if title is not None:
+            parameters.append('title:{}'.format(title))
+        if year is not None:
+            parameters.append('year:{}'.format(year))
+        if records is not None:
+            parameters.append('p={}'.format(records))
+        if start is not None:
+            parameters.append('s={}'.format(start))
 
         return parameters
 

--- a/src/arcas/arXiv/main.py
+++ b/src/arcas/arXiv/main.py
@@ -55,18 +55,19 @@ class Arxiv(Api):
         return raw_articles
 
     @staticmethod
-    def parameters_fix(arguments):
+    def parameters_fix(author=None, title=None, abstract=None, year=None,
+                       records=None, start=None):
         parameters = []
-        if arguments['-a'] is not None:
-            parameters.append('au:{}'.format(arguments['-a']))
-        if arguments['-t'] is not None:
-            parameters.append('ti:{}'.format(arguments['-t']))
-        if arguments['-b'] is not None:
-            parameters.append('abs:{}'.format(arguments['-b']))
-        if arguments['-r'] is not None:
-            parameters.append('max_results={}'.format(arguments['-r']))
-        if arguments['-s'] is not None:
-            parameters.append('start={}'.format(arguments['-s']))
+        if author is not None:
+            parameters.append('au:{}'.format(author))
+        if title is not None:
+            parameters.append('ti:{}'.format(title))
+        if abstract is not None:
+            parameters.append('abs:{}'.format(abstract))
+        if records is not None:
+            parameters.append('max_results={}'.format(records))
+        if start is not None:
+            parameters.append('start={}'.format(start))
 
         return parameters
 

--- a/src/arcas/nature/main.py
+++ b/src/arcas/nature/main.py
@@ -86,19 +86,20 @@ class Nature(Api):
         return self.dict_to_dataframe(raw_article)
 
     @staticmethod
-    def parameters_fix(arguments):
+    def parameters_fix(author=None, title=None, abstract=None, year=None,
+                       records=None, start=None):
         parameters = []
-        if arguments['-a'] is not None:
-            parameters.append('dc.creator={}'.format(arguments['-a']))
-        if arguments['-t'] is not None:
-            parameters.append('dc.title adj {}'.format(arguments['-t']))
-        if arguments['-b'] is not None:
-            parameters.append('dc.description adj {}'.format(arguments['-b']))
-        if arguments['-y'] is not None:
-            parameters.append('prism.publicationDate={}'.format(arguments['-y']))
-        if arguments['-r'] is not None:
-            parameters.append('maximumRecords={}'.format(arguments['-r']))
-        if arguments['-s'] is not None:
-            parameters.append('startRecord={}'.format(arguments['-s']))
+        if author is not None:
+            parameters.append('dc.creator={}'.format(author))
+        if title is not None:
+            parameters.append('dc.title adj {}'.format(title))
+        if abstract is not None:
+            parameters.append('dc.description adj {}'.format(abstract))
+        if year is not None:
+            parameters.append('prism.publicationDate={}'.format(year))
+        if records is not None:
+            parameters.append('maximumRecords={}'.format(records))
+        if start is not None:
+            parameters.append('startRecord={}'.format(start))
 
         return parameters

--- a/src/arcas/tools.py
+++ b/src/arcas/tools.py
@@ -65,7 +65,8 @@ class Api():
         pass
 
     @staticmethod
-    def parameters_fix(arguments):
+    def parameters_fix(author=None, title=None, abstract=None, year=None,
+                       records=None, start=None):
         pass
 
     @staticmethod

--- a/tests/tests_arxiv.py
+++ b/tests/tests_arxiv.py
@@ -65,7 +65,10 @@ class TestArxiv(unittest.TestCase):
 
     @given(dummy_arguments)
     def test_parameters(self, arguments):
-        parameters = self.api.parameters_fix(arguments)
+        parameters = self.api.parameters_fix(author=arguments['-a'], title=arguments['-t'],
+                                             abstract=arguments['-b'],
+                                             records=arguments['-r'],
+                                             start=arguments['-s'])
         self.assertEqual('au:{}'.format(arguments['-a']), parameters[0])
         self.assertEqual('ti:{}'.format(arguments['-t']), parameters[1])
         self.assertEqual('abs:{}'.format(arguments['-b']), parameters[2])

--- a/tests/tests_ieee.py
+++ b/tests/tests_ieee.py
@@ -71,7 +71,11 @@ class TestIEEE(unittest.TestCase):
 
     @given(dummy_arguments)
     def test_parameters(self, arguments):
-        parameters = self.api.parameters_fix(arguments)
+        parameters = self.api.parameters_fix(author=arguments['-a'], title=arguments['-t'],
+                                             abstract=arguments['-b'],
+                                             year=arguments['-y'],
+                                             records=arguments['-r'],
+                                             start=arguments['-s'])
         self.assertEqual('au={}'.format(arguments['-a']), parameters[0])
         self.assertEqual('ti={}'.format(arguments['-t']), parameters[1])
         self.assertEqual('ab={}'.format(arguments['-b']), parameters[2])

--- a/tests/tests_nature.py
+++ b/tests/tests_nature.py
@@ -68,7 +68,11 @@ class TestNature(unittest.TestCase):
 
     @given(dummy_arguments)
     def test_parameters(self, arguments):
-        parameters = self.api.parameters_fix(arguments)
+        parameters = self.api.parameters_fix(author=arguments['-a'], title=arguments['-t'],
+                                             abstract=arguments['-b'],
+                                             year=arguments['-y'],
+                                             records=arguments['-r'],
+                                             start=arguments['-s'])
         self.assertEqual('dc.creator={}'.format(arguments['-a']), parameters[0])
         self.assertEqual('dc.title adj {}'.format(arguments['-t']),
                          parameters[1])

--- a/tests/tests_plos.py
+++ b/tests/tests_plos.py
@@ -58,7 +58,11 @@ class TestArxiv(unittest.TestCase):
 
     @given(dummy_arguments)
     def test_parameters(self, arguments):
-        parameters = self.api.parameters_fix(arguments)
+        parameters = self.api.parameters_fix(author=arguments['-a'], title=arguments['-t'],
+                                             abstract=arguments['-b'],
+                                             year=arguments['-y'],
+                                             records=arguments['-r'],
+                                             start=arguments['-s'])
         self.assertEqual('author:{}'.format(arguments['-a']), parameters[0])
         self.assertEqual('title:{}'.format(arguments['-t']), parameters[1])
         self.assertEqual('abstract:{}'.format(arguments['-b']), parameters[2])

--- a/tests/tests_springer.py
+++ b/tests/tests_springer.py
@@ -65,7 +65,11 @@ class TestSpinger(unittest.TestCase):
 
     @given(dummy_arguments)
     def test_parameters(self, arguments):
-        parameters = self.api.parameters_fix(arguments)
+        parameters = self.api.parameters_fix(author=arguments['-a'], title=arguments['-t'],
+                                             abstract=arguments['-b'],
+                                             year=arguments['-y'],
+                                             records=arguments['-r'],
+                                             start=arguments['-s'])
         self.assertEqual('name:{}'.format(arguments['-a']), parameters[0])
         self.assertEqual('title:{}'.format(arguments['-t']),
                          parameters[1])


### PR DESCRIPTION
This closes #18 

The arguments of the search have been passed as a dictionary in the function
fix parameters. Fix parameters function is in charge of creating the url.

This was causing an issue because the user had to pass a dictionary
with all the parameters. This is now removed and the user can pass
an argument straight to the function. Example:

paramaters = api.fix_parameters(title='sun')

To implement this change the passing arguments for the fix parameters
have change. Followed by alterations to each apis fix parameters function.

Tests have been re written, tested and failed and then passed.